### PR TITLE
feat: add ANTHROPIC_BASE_URL and ANTHROPIC_AUTH_TOKEN env configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,9 @@ JENKINS_JOBS={"Patch":"MyProject/Patch_Build","Release":"MyProject/Release_Build
 # Claude Configuration
 CLAUDE_COMMAND=claude
 CLAUDE_TIMEOUT_MS=300000
+# Optional: Anthropic API configuration (for custom API endpoints)
+ANTHROPIC_BASE_URL=https://api.anthropic.com
+ANTHROPIC_AUTH_TOKEN=your-anthropic-auth-token
 
 # Webhook Configuration
 WEBHOOK_PORT=4567

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -60,6 +60,8 @@ export function loadConfig(): AppConfig {
     claude: {
       command: optional('CLAUDE_COMMAND', 'claude'),
       timeoutMs: optionalInt('CLAUDE_TIMEOUT_MS', 300000),
+      anthropicBaseUrl: process.env.ANTHROPIC_BASE_URL,
+      anthropicAuthToken: process.env.ANTHROPIC_AUTH_TOKEN,
     },
     webhook: {
       port: optionalInt('WEBHOOK_PORT', 4567),

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -19,6 +19,8 @@ export interface JenkinsConfig {
 export interface ClaudeConfig {
   command: string;
   timeoutMs: number;
+  anthropicBaseUrl?: string;
+  anthropicAuthToken?: string;
 }
 
 export interface WebhookConfig {

--- a/src/services/claude.ts
+++ b/src/services/claude.ts
@@ -3,8 +3,16 @@ import { getConfig } from '../config/index.js';
 
 export async function* brainstorm(prompt: string): AsyncGenerator<string> {
   const cfg = getConfig().claude;
+  const env: Record<string, string> = { ...process.env } as Record<string, string>;
+  if (cfg.anthropicBaseUrl) {
+    env.ANTHROPIC_BASE_URL = cfg.anthropicBaseUrl;
+  }
+  if (cfg.anthropicAuthToken) {
+    env.ANTHROPIC_AUTH_TOKEN = cfg.anthropicAuthToken;
+  }
   const proc = spawn(cfg.command, ['-p', prompt, '--output-format', 'stream-json'], {
     stdio: ['ignore', 'pipe', 'pipe'],
+    env,
   });
 
   const timeout = setTimeout(() => {


### PR DESCRIPTION
Add support for custom Anthropic API endpoint configuration:
- Add anthropicBaseUrl and anthropicAuthToken fields to ClaudeConfig schema
- Load ANTHROPIC_BASE_URL and ANTHROPIC_AUTH_TOKEN from environment
- Pass these environment variables to the spawned claude process
- Update .env.example with new optional configuration

https://claude.ai/code/session_01KYsbsUQn9tj2X6XLFYZAT9