### PR TITLE
feat: add Claude project directory and skip-permissions config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,10 @@ JENKINS_JOBS={"Patch":"MyProject/Patch_Build","Release":"MyProject/Release_Build
 # Claude Configuration
 CLAUDE_COMMAND=claude
 CLAUDE_TIMEOUT_MS=300000
+# Optional: Project directory for Claude Code to run in
+CLAUDE_PROJECT_DIR=/path/to/your/project
+# Optional: Skip permissions check (use with caution)
+CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS=false
 # Optional: Anthropic API configuration (for custom API endpoints)
 ANTHROPIC_BASE_URL=https://api.anthropic.com
 ANTHROPIC_AUTH_TOKEN=your-anthropic-auth-token

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -62,6 +62,8 @@ export function loadConfig(): AppConfig {
       timeoutMs: optionalInt('CLAUDE_TIMEOUT_MS', 300000),
       anthropicBaseUrl: process.env.ANTHROPIC_BASE_URL,
       anthropicAuthToken: process.env.ANTHROPIC_AUTH_TOKEN,
+      projectDir: process.env.CLAUDE_PROJECT_DIR,
+      dangerouslySkipPermissions: optionalBool('CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS', false),
     },
     webhook: {
       port: optionalInt('WEBHOOK_PORT', 4567),

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -21,6 +21,8 @@ export interface ClaudeConfig {
   timeoutMs: number;
   anthropicBaseUrl?: string;
   anthropicAuthToken?: string;
+  projectDir?: string;
+  dangerouslySkipPermissions?: boolean;
 }
 
 export interface WebhookConfig {

--- a/src/services/claude.ts
+++ b/src/services/claude.ts
@@ -10,10 +10,23 @@ export async function* brainstorm(prompt: string): AsyncGenerator<string> {
   if (cfg.anthropicAuthToken) {
     env.ANTHROPIC_AUTH_TOKEN = cfg.anthropicAuthToken;
   }
-  const proc = spawn(cfg.command, ['-p', prompt, '--output-format', 'stream-json'], {
+
+  // Build command arguments
+  const args = ['-p', prompt, '--output-format', 'stream-json'];
+  if (cfg.dangerouslySkipPermissions) {
+    args.push('--dangerously-skip-permissions');
+  }
+
+  // Build spawn options
+  const spawnOptions: { stdio: ['ignore', 'pipe', 'pipe']; env: Record<string, string>; cwd?: string } = {
     stdio: ['ignore', 'pipe', 'pipe'],
     env,
-  });
+  };
+  if (cfg.projectDir) {
+    spawnOptions.cwd = cfg.projectDir;
+  }
+
+  const proc = spawn(cfg.command, args, spawnOptions);
 
   const timeout = setTimeout(() => {
     proc.kill('SIGTERM');


### PR DESCRIPTION
Add support for configuring Claude Code project directory and --dangerously-skip-permissions flag via environment variables:
- CLAUDE_PROJECT_DIR: Set the working directory for Claude CLI
- CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS: Enable skip permissions mode

https://claude.ai/code/session_01Spj9nPiS1Aq8oLkXYnMynk