### PR TITLE
feat: replace GITLAB_DEFAULT_PROJECT_ID with GITLAB_DEFAULT_PROJECT

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@ SLACK_APP_TOKEN=xapp-your-app-level-token
 # GitLab Configuration
 GITLAB_URL=https://gitlab.example.com
 GITLAB_TOKEN=your-gitlab-private-token
-GITLAB_DEFAULT_PROJECT_ID=1
+GITLAB_DEFAULT_PROJECT=namespace/project
 
 # Jenkins Configuration
 JENKINS_URL=https://jenkins.example.com

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ src/
 | 变量 | 默认值 | 说明 |
 |------|--------|------|
 | `GITLAB_URL` | `https://gitlab.example.com` | GitLab 实例 URL (需有效 HTTP/HTTPS) |
-| `GITLAB_DEFAULT_PROJECT_ID` | `1` | 默认项目 ID (正整数) |
+| `GITLAB_DEFAULT_PROJECT` | `namespace/project` | 默认项目路径 (如 "group/project") |
 | `JENKINS_URL` | `https://jenkins.example.com` | Jenkins 实例 URL (需有效 HTTP/HTTPS) |
 | `JENKINS_JOBS` | 内置默认 | Jenkins Job 映射 JSON |
 | `CLAUDE_COMMAND` | `claude` | Claude CLI 命令路径 |

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ SLACK_APP_TOKEN=xapp-...
 # GitLab 配置
 GITLAB_URL=https://your-gitlab.com
 GITLAB_TOKEN=glpat-...
-GITLAB_DEFAULT_PROJECT_ID=42
+GITLAB_DEFAULT_PROJECT=mygroup/myproject
 
 # Jenkins 配置
 JENKINS_URL=https://your-jenkins.com

--- a/src/config/env-validator.ts
+++ b/src/config/env-validator.ts
@@ -128,11 +128,11 @@ export function validateConfig(config: AppConfig): void {
     });
   }
 
-  if (config.gitlab.defaultProjectId <= 0) {
+  if (!isNonEmptyString(config.gitlab.defaultProject)) {
     errors.push({
-      param: 'GITLAB_DEFAULT_PROJECT_ID',
-      message: 'GitLab Default Project ID must be a positive integer',
-      value: String(config.gitlab.defaultProjectId),
+      param: 'GITLAB_DEFAULT_PROJECT',
+      message: 'GitLab Default Project must be a non-empty string (e.g., "namespace/project")',
+      value: config.gitlab.defaultProject,
     });
   }
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -55,7 +55,7 @@ export function loadConfig(): AppConfig {
     gitlab: {
       url: optional('GITLAB_URL', 'https://gitlab.example.com'),
       token: required('GITLAB_TOKEN'),
-      defaultProjectId: optionalInt('GITLAB_DEFAULT_PROJECT_ID', 1),
+      defaultProject: optional('GITLAB_DEFAULT_PROJECT', 'namespace/project'),
     },
     jenkins: {
       url: optional('JENKINS_URL', 'https://jenkins.example.com'),

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -6,7 +6,7 @@ export interface SlackConfig {
 export interface GitLabConfig {
   url: string;
   token: string;
-  defaultProjectId: number;
+  defaultProject: string;
 }
 
 export interface JenkinsConfig {

--- a/src/services/gitlab.ts
+++ b/src/services/gitlab.ts
@@ -28,7 +28,7 @@ function api(path: string, init?: RequestInit) {
 }
 
 function projectPath() {
-  return `/projects/${getConfig().gitlab.defaultProjectId}`;
+  return `/projects/${encodeURIComponent(getConfig().gitlab.defaultProject)}`;
 }
 
 export async function createIssue(title: string, description?: string) {


### PR DESCRIPTION
Change GitLab project configuration from numeric ID to project path/name. GitLab API supports URL-encoded project paths (e.g., "namespace/project") which is more user-friendly than numeric project IDs.

- Update config schema to use string type for defaultProject
- Update config loader to read GITLAB_DEFAULT_PROJECT env var
- Update env validator to validate non-empty string
- Update gitlab service to URL-encode project path for API calls
- Update documentation (.env.example, CLAUDE.md, README.md, technical-reference.md)

https://claude.ai/code/session_01XuAEvNgVTru4Q6uNrF3oi9