### PR TITLE
fix: 添加 --verbose 参数修复 Claude CLI stream-json 错误

### DIFF
--- a/src/services/claude.ts
+++ b/src/services/claude.ts
@@ -13,7 +13,8 @@ export async function* askClaude(prompt: string, sessionId?: string, resume = fa
   }
 
   // Build command arguments
-  const args = ['-p', prompt, '--output-format', 'stream-json'];
+  // --verbose is required when using -p with --output-format stream-json
+  const args = ['-p', prompt, '--output-format', 'stream-json', '--verbose'];
   if (sessionId) {
     if (resume) {
       args.push('--resume', sessionId);


### PR DESCRIPTION
Claude CLI 更新后，使用 -p (print mode) 与 --output-format stream-json 时 需要同时添加 --verbose 参数，否则会报错：
"When using --print, --output-format=stream-json requires --verbose"

https://claude.ai/code/session_0176Zm91PMkqRp2XS8sH645j